### PR TITLE
build(release): bump version from 3.1.2 to 3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,25 @@
 # Changelog
 
-## v1.2.0-ruby3.1-20220418 - [Danilo Carolino](@danilogco)
+## [1.2.1] - 2022-12-01
 
-* Bump `ruby` version to v3.1.2
+### Changed
 
-## v1.1.0-ruby3.1-20220227 - [Danilo Carolino](@danilogco)
+- Bump `ruby` version to v3.1.3
 
-* Bump `ruby` version to v3.1.1
+## [1.2.0] - 2022-04-18
 
-## v1.0.0
+### Changed
 
-* Initial release.
+- Bump `ruby` version to v3.1.2
+
+## [1.1.0] - 2022-02-27
+
+### Changed
+
+- Bump `ruby` version to v3.1.1
+
+## [1.0.0] - 2021-12-23
+
+### Added
+
+- Initial release.

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -18,7 +18,7 @@ docker build -t rails_ruby3.1 .
 
 ```bash
 docker tag rails_ruby3.1:latest public.ecr.aws/qflash/rails_ruby3.1:latest
-docker tag rails_ruby3.1:latest public.ecr.aws/qflash/rails_ruby3.1:1.2.0
+docker tag rails_ruby3.1:latest public.ecr.aws/qflash/rails_ruby3.1:1.2.1
 docker push public.ecr.aws/qflash/rails_ruby3.1:latest
-docker push public.ecr.aws/qflash/rails_ruby3.1:1.2.0
+docker push public.ecr.aws/qflash/rails_ruby3.1:1.2.1
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.2-slim-buster
+FROM ruby:3.1.3-slim-buster
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 LANGUAGE=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Versions available:
 
 | Ruby  | Branch | Latest release |
 |-------|--------|----------------|
-| 3.1.2 |  [Link](https://github.com/Quasar-Flash/rails_ruby3/tree/ruby_3.1)  |     [Link](https://github.com/Quasar-Flash/rails_ruby3/releases/tag/v1.2.0-ruby3.1)       |
+| 3.1.3 |  [Link](https://github.com/Quasar-Flash/rails_ruby3/tree/ruby_3.1)  |     [Link](https://github.com/Quasar-Flash/rails_ruby3/releases/tag/v1.2.1)       |
 | 3.0.3 |  [Link](https://github.com/Quasar-Flash/rails_ruby3/tree/ruby_3.0.3)  |     [Link](https://github.com/Quasar-Flash/rails_ruby3/releases/tag/v1.0.0)       |
 
 ## How to use it


### PR DESCRIPTION
## [1.2.1] - 2022-12-01

### Changed

- Bump `ruby` version to v3.1.3